### PR TITLE
Add a Docker Compose file

### DIFF
--- a/Dockerfile_Receiver
+++ b/Dockerfile_Receiver
@@ -1,0 +1,9 @@
+FROM node:14.16.0-alpine
+
+COPY ./AMR_Interop_Standard.json /app/AMR_Interop_Standard.json
+COPY ./examples/statusReport1.json /app/examples/statusReport1.json
+COPY ./MassRobotics-AMR-Receiver /app/MassRobotics-AMR-Receiver
+WORKDIR /app/MassRobotics-AMR-Receiver
+RUN npm run install-server
+
+ENTRYPOINT npm run start

--- a/Dockerfile_Sender
+++ b/Dockerfile_Sender
@@ -1,0 +1,7 @@
+FROM python:3.6.9
+
+COPY ./MassRobotics-AMR-Sender /app
+WORKDIR /app
+RUN pip install websockets
+
+ENTRYPOINT python client.py "ws://receiver:3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: "3"
+
+services:
+  receiver:
+    image: receiver
+    build:
+      context: .
+      dockerfile: Dockerfile_Receiver
+    container_name: receiver
+    ports:
+      - "3000:3000"
+    volumes:
+      - node_modules:/app/MassRobotics-AMR-Receiver/node_modules
+    tty: true
+  sender:
+    image: sender
+    build:
+      context: .
+      dockerfile: Dockerfile_Sender
+    container_name: sender
+    depends_on:
+      - "receiver"
+    tty: true
+volumes:
+  node_modules:


### PR DESCRIPTION
We have created a Dockerfile that runs `MassRobotics-AMR-Receiver` and `MassRobotics-AMR-Sender`. We believe that this will lower the threshold for trying to run them.

`MassRobotics-AMR-Receiver` and `MassRobotics-AMR-Sender` will work with the following command.
( Assumption: `docker-compose` works on your environment )

```sh
$ cd AMR_Interop_Standard
$ docker-compose build
$ docker-compose up
$ # open http://localhost:3000/ in a browser
```