### PR TITLE
update upper limit

### DIFF
--- a/AMR_Interop_Standard.json
+++ b/AMR_Interop_Standard.json
@@ -180,7 +180,7 @@
         "description": "Percentage of battery remaining",
         "type": "number",
         "minimum": 0,
-	"maximum": 100
+        "maximum": 100
       },
       "remainingRunTime" : {
         "description": "Estimated remaining runtime in hours",
@@ -191,7 +191,7 @@
         "description": "Percentage of capacity still available",
         "type": "number",
         "minimum": 0,
-	"maximum": 100
+        "maximum": 100
       },
       "errorCodes" : {
         "description": "List of current error states - should be omitted for normal operation",

--- a/AMR_Interop_Standard.json
+++ b/AMR_Interop_Standard.json
@@ -180,7 +180,7 @@
         "description": "Percentage of battery remaining",
         "type": "number",
         "minimum": 0,
-        "inclusiveMaximum": 100
+	"maximum": 100
       },
       "remainingRunTime" : {
         "description": "Estimated remaining runtime in hours",
@@ -191,7 +191,7 @@
         "description": "Percentage of capacity still available",
         "type": "number",
         "minimum": 0,
-        "inclusiveMaximum": 100
+	"maximum": 100
       },
       "errorCodes" : {
         "description": "List of current error states - should be omitted for normal operation",


### PR DESCRIPTION
close #16 

Change `inclusiveMaximum` to `maximum`.
This will make it possible to determine that values exceeding 100 are abnormal. (In this setting, 100 is treated as valid).
