### PR TITLE
UUID validation also enabled capital letters A through F

### DIFF
--- a/AMR_Interop_Standard.json
+++ b/AMR_Interop_Standard.json
@@ -28,7 +28,7 @@
           "description": "Id of planarDatum AMR is referencing",
           "type": "string",
           "format": "uuid",
-          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+          "pattern": "^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"
         }
       },
       "additionalProperties": false
@@ -54,7 +54,7 @@
           "description": "Only necessary if different from AMRs current planarDatum",
           "type": "string",
           "format": "uuid",
-          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+          "pattern": "^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"
         }
       }, 
       "additionalProperties": false
@@ -69,7 +69,7 @@
         "description": "UUID specified by RFC4122 that all subsequent messages should reference",
         "type": "string",
         "format": "uuid",
-        "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+        "pattern": "^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"
       },
       "timestamp": { "type": "string", "format": "date-time" },
       "manufacturerName": { "type": "string" },
@@ -159,7 +159,7 @@
         "description": "UUID specified in the identityAndCapability message",
         "type": "string",
         "format": "uuid",
-        "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+        "pattern": "^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"
       },
       "timestamp": { "type": "string", "format": "date-time" },
       "operationalState": { 


### PR DESCRIPTION
[Use lowercase for UUIDs as defined by the schema file #20](https://github.com/MassRobotics-AMR/AMR_Interop_Standard/pull/20)
This is another solution for

[add uuid's pattern #12](https://github.com/MassRobotics-AMR/AMR_Interop_Standard/pull/12) was disallowing uppercase letters. Updated the schema so that uppercase is enabled.